### PR TITLE
Add NGINX with forwarding to FastAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM python:3.14
-WORKDIR /app
-COPY ./src/backend/requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
-COPY ./src /app/src
-CMD ["fastapi", "run", "src/backend/main.py", "--port", "80"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:latest
+WORKDIR /app
+CMD ["/bin/sh", "/app/start_server.sh"]
+RUN apt update && apt install -y nginx
+COPY ./src/backend/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt --break-system-packages
+COPY deploy/start_server.sh /app/start_server.sh
+COPY deploy/nginx_config.conf /etc/nginx/nginx.conf
+COPY ./src /app/src

--- a/deploy/nginx_config.conf
+++ b/deploy/nginx_config.conf
@@ -1,0 +1,98 @@
+user www-data;
+worker_processes auto;
+worker_cpu_affinity auto;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 768;
+        # multi_accept on;
+}
+
+http {
+
+        ##
+        # Basic Settings
+        ##
+
+        server {
+            # location /api/ {
+            #     proxy_pass http://127.0.0.1:9000/;
+            # }
+
+            location / {
+                root /app/src/frontend;
+            }
+
+            location /api/ {
+                proxy_pass http://0.0.0.0:9000/;
+            }
+        }
+
+        # sendfile on;
+        # tcp_nopush on;
+        # types_hash_max_size 2048;
+        # server_tokens off; # Recommended practice is to turn this off
+
+        # # server_names_hash_bucket_size 64;
+        # # server_name_in_redirect off;
+
+        # include /etc/nginx/mime.types;
+        # default_type application/octet-stream;
+
+        # ##
+        # # SSL Settings
+        # ##
+
+        # ssl_protocols TLSv1.2 TLSv1.3; # Dropping SSLv3 (POODLE), TLS 1.0, 1.1
+        # ssl_prefer_server_ciphers off; # Don't force server cipher order.
+
+        # ##
+        # # Logging Settings
+        # ##
+
+        # access_log /var/log/nginx/access.log;
+
+        # ##
+        # # Gzip Settings
+        # ##
+
+        # gzip on;
+
+        # # gzip_vary on;
+        # # gzip_proxied any;
+        # # gzip_comp_level 6;
+        # # gzip_buffers 16 8k;
+        # # gzip_http_version 1.1;
+        # # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+        # ##
+        # # Virtual Host Configs
+        # ##
+
+        # include /etc/nginx/conf.d/*.conf;
+        # include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#       # See sample authentication script at:
+#       # http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#       # auth_http localhost/auth.php;
+#       # pop3_capabilities "TOP" "USER";
+#       # imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#       server {
+#               listen     localhost:110;
+#               protocol   pop3;
+#               proxy      on;
+#       }
+#
+#       server {
+#               listen     localhost:143;
+#               protocol   imap;
+#               proxy      on;
+#       }
+#}

--- a/deploy/start_server.sh
+++ b/deploy/start_server.sh
@@ -1,0 +1,2 @@
+nginx
+fastapi run src/backend/main.py --port 9000

--- a/deploy/start_server.sh
+++ b/deploy/start_server.sh
@@ -1,2 +1,2 @@
 nginx
-fastapi run src/backend/main.py --port 9000
+fastapi run src/backend/main.py --port 9000 --forwarded-allow-ips="*"

--- a/docker_logs.sh
+++ b/docker_logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ "$EUID" -ne 0 ]
+  then echo "This script must be run with sudo, like so: sudo $0" 
+  exit 1
+fi
+if ! command -v docker &> /dev/null;
+  then echo "Docker installation not found. Please install docker." 
+  exit 1
+fi
+sudo docker container logs rpi_games_docker_container

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -7,6 +7,7 @@ if ! command -v docker &> /dev/null;
   then echo "Docker installation not found. Please install docker." 
   exit 1
 fi
-sudo docker build -t rpi_games_docker_image .
+sudo docker build -t rpi_games_docker_image . -f deploy/Dockerfile
+docker container stop rpi_games_docker_container
 sudo docker container rm rpi_games_docker_container
 sudo docker run -d --name rpi_games_docker_container -p 80:80 rpi_games_docker_image

--- a/docker_terminal.sh
+++ b/docker_terminal.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ "$EUID" -ne 0 ]
+  then echo "This script must be run with sudo, like so: sudo $0" 
+  exit 1
+fi
+if ! command -v docker &> /dev/null;
+  then echo "Docker installation not found. Please install docker." 
+  exit 1
+fi
+sudo docker exec -it rpi_games_docker_container /bin/bash


### PR DESCRIPTION
## What Issue # does this fix

N/A

## What does this do

Adds an NGINX frontend HTTP server, redirecting calls to `/api/` to the FastAPI backend. Also improves Docker design, with logs and terminal checking command.

## How to test this

1. Run `sudo ./docker_start.sh`
2. Visit [`http://localhost`](http://localhost)
3. Observe sample `index.html` page
4. Visit [`http://localhost/api/get-lobbies`](http://localhost/api/get-lobbies)
5. Observe sample api response (empty JSON `[]`)

## Miscellaneous

Include what the person merging has to do here

- [ ] Does it follow naming convention
